### PR TITLE
fix: drop Node.js <14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - 12.x
           - 14.x
           - 16.x
+          - 18.x
         os:
           - ubuntu-latest
           - windows-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,9 +1015,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+      "version": "14.18.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+      "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib/**/*"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=14.18.20"
   },
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.build.json",
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/ffmpeg-static": "^3.0.1",
     "@types/jest": "^27.0.0",
-    "@types/node": "^8.10.39",
+    "@types/node": "^14.18.26",
     "@types/rimraf": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
@@ -38,7 +38,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^28.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.0.0"
+    "typescript": "^4.6.3"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v14 is now the minimum required version